### PR TITLE
Create Build Workflow and Export to `edm-publishing`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
 
 
       - name: install dependencies ...
+        working-directory: cbbr_build
         run: |
           sudo apt update
           sudo apt install -y gdal-bin
@@ -48,4 +49,25 @@ jobs:
           mc alias set spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
           sudo apt install python3-pip
           pip3 install requirements.txt
+
+      - name: Dataloading ...
+        working_directory: cbbr_build
+        run: ./01_dataloading.sh
+
+      - name: Create Build Tables and Normalize CBBR Values
+        working_directory: cbbr_build
+        run: ./02_cbbr.sh
+
+      - name: Assign Geometries from DOITT, Parks, Facilties DB and Run Spatial
+        working_directory: cbbr_build
+        run: ./03_spatial.sh
+
+      - name: Export CBBR Output to DO (edm-publishing)
+        working_directory: cbbr_build
+        run: ./04_export.sh
+
+      - name: Archive CBBR to EDM-DATA 
+        working_diretory: cbbr_build
+        run: ./05_archive.sh
+
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build - Run Community Board Budget Requests (CBBR) Update 
+name: Build - Run CBBR Build 
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build - Run Community Board Budget Requests (CBBR) Update 
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_build:
+        description: "Run the CBBR Build"
+        type: boolean
+        required: true
+        default: false
+      run_export:
+        description: "Run Export Step and Upload to DO"
+        type: boolean
+        required: true
+        default: false
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    services:
+      postgres:
+        image: postgis/postgis:12-3.0-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      BUILD_ENGINE: postgresql://postgres:postgres@localhost:5432/postgres
+      EDM_DATA: ${{ secrets.EDM_DATA }}
+      AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+
+
+      - name: install dependencies ...
+        run: |
+          sudo apt update
+          sudo apt install -y gdal-bin
+          curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+          chmod +x mc
+          sudo mv ./mc /usr/bin
+          mc alias set spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
+          sudo apt install python3-pip
+          pip3 install requirements.txt
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,13 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout 
+        uses: actions/checkout@v2
+        
+      - name: Setup python
+        uses: actions/setup-python@v4.5.0
+        with:
+          python-version: "3.11.1"
 
 
       - name: install dependencies ...


### PR DESCRIPTION
Addresses issue #30.

## Motivation:

- Create a Build Action to run the CBBR build on Github Actions workflow and push outputs to [edm-publishing](https://cloud.digitalocean.com/spaces/edm-publishing?i=266877) which is a standard process for many of our other data products.

## Changes:
- Create a `build.yml` template similar to other data products that utilizes the bash scripts to build CBBR (`Dataloading`, Create `CBBR` tables and normalize values, create `spatial` data tables (i.e. geocode applicable records and create tables associated with manual corrections), `Export` to DigitalOcean and `Archive` to `edm-data` DigitalOcean cluster.

## Notes:
- I don't have an effective way of testing Github Actions/workflows without merging to them to `main`. I know there is a [Github Client](https://cli.github.com/) you can run on the terminal but as this isn't a breaking change to any of the code I think it would be okay to merge and continue developing on another feature branch but wanted to get this started so we have the ability to export outside of the repos `output/FY2024` folder 

## TODO:
- Test Workflow 
- Originally, I had planned on incorporating applying the manual researched shapefiles/geodatabase files but I think it makes sense to split this work up into separate PR's (hence the naming of the feature branch) 